### PR TITLE
add wrapper for la_generic

### DIFF
--- a/src/smt/veriT.lean
+++ b/src/smt/veriT.lean
@@ -40,6 +40,7 @@ inductive proof_step
 --  * right_assoc_elim  : valid: {(= (f t1 ... tn ) (f t1 (f t2 ... (f tn−1 tn ) ... )}
 --  * left_assoc_elim   : valid: {(= (f t1 ... tn ) (f ... (f (f t1 t2 ) t3 ) ... tn )}
 --  * la_rw_eq          : valid: {(= (a = b) (and (a <= b) (b <= a))}
+| la_generic (_ : list sexpr)
 --  * la_generic        : valid: not yet defined
 --  * lia_generic       : valid: not yet defined
 --  * nla_generic       : valid: not yet defined


### PR DESCRIPTION
My sample problem generated this trace:
```
1:(input ((< a_val 2)))
2:(input ((= 0 (+ a_val (- 2)))))
3:(la_generic ((not (< a_val 2)) (not (= 0 (+ a_val (- 2))))))
4:(resolution () 3 1 2)
```
But `la_generic` wasn't supported out of the box, creating an error for Lean.  I added a field parser that gets past the error.  The selection here is, I think, correct.