### PR TITLE
Non-working transitivity test

### DIFF
--- a/src/smt/veriT.lean
+++ b/src/smt/veriT.lean
@@ -223,6 +223,12 @@ meta def run_step (m : rb_map ℕ expr) : ℕ × proof_step → tactic (rb_map �
   clear_except hs,
   tautology tt,
   pure m
+| (i, la_generic es) := do
+  es.mmap' $ λ e, do { e' ← expr.of_sexpr e,
+                       h ← assert `h e',
+                       -- clear_except [],
+                       pure $ m.insert i h},
+  pure m
 
 end smt.veriT
 

--- a/test/transitivity_of_lt.lean
+++ b/test/transitivity_of_lt.lean
@@ -1,0 +1,6 @@
+import «smt-lean»
+
+example (x y z : ℤ) (h : x < y) (h' : y < z) : x < z :=
+begin
+  veriT,
+end


### PR DESCRIPTION
This test doesn't work.  Progress depends on integration of `la_generic` into `run_step`.  I've added my initial implementation.